### PR TITLE
fix the error that the last value contain `]`

### DIFF
--- a/src/comm/proto/protocol.h
+++ b/src/comm/proto/protocol.h
@@ -110,7 +110,7 @@ namespace bm
                 return v;
             }
 
-            string nv = v.substr(l + 1, r - l);
+            string nv = v.substr(l + 1, r - 1);
             if (m != string::npos && is_int)
             {
                 vector<string> vs = TC_Common::sepstr<string>(nv, "-");


### PR DESCRIPTION
fix the error that the last value contain `]` while using random string like `[aaa,bbb,ccc]`, which will get `ccc]` but not `ccc`.

修复 `string` 类型入参使用 `限定随机值` 时，最后一个随机值会包含字符 `]` 的问题